### PR TITLE
Fix/base url for logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ After cloning the project, install it using
 
 ### `yarn`
 
+Create `.env.local` file at project root directory [like here](https://docs.frontegg.com/docs/nextjs-12-13-ssr-hosted-login#step-4-setup-environment)
+
+Make sure that `env.local` contains `NEXT_PUBLIC_FRONTEGG_APP_URL` identical to `FRONTEGG_APP_URL`, so frontend gets the value for redirecting requests.
+
 In order to run the project, run
 ### `yarn run dev`
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { withFronteggApp } from '@frontegg/nextjs';
+import { AppProps } from 'next/app';
 
 function CustomApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,7 @@ export default function MyPage({ products }) {
   const {user} = useAuth();
   
   //baseUrl should be your FRONTEGG_APP_URL from .env.local
-  const baseUrl =  'FRONTEGG_APP_URL'
+  const baseUrl =  process.env.NEXT_PUBLIC_FRONTEGG_APP_URL;
   
   const logout = () => {
     window.location.href = `${baseUrl}/account/logout`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleResolution": "node",
     "jsx": "preserve"
   },
   "include": [


### PR DESCRIPTION
Logout button redirected to 404 because there was a dummy value in place of an environment variable in source, so I fixed it to use NEXT_PUBLIC_* convention to get that variable instead, and instructed to use it in the README.

Also some minor fixes to make the thing build and to fix module resolution in IntelliJ.
